### PR TITLE
Add 'requests' to requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,8 @@ setuptools.setup(
         "Operating System :: OS Independent"
     ],
     packages=setuptools.find_packages(),
-    python_requires=">=3.6"
+    python_requires=">=3.6",
+    install_requires=[
+        'requests',
+    ]
 )


### PR DESCRIPTION
Hi Dillan,
I hope this message finds you well. I wanted to reach out and express my appreciation for your amazing library. It's been incredibly helpful.

While installing the library's in a new enviroment, I noticed that the requests requirement was missing from the setup.py file. Understanding the importance of this dependency, I took the liberty of making the necessary adjustment. I have created a pull request that adds the requests requirement to the install_requires section in the setup.py file.

I believe this addition will help ensure that users can easily install and use your library without running into dependency issues.